### PR TITLE
Fix crash on startup for latest docker version

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -27,10 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	dockerHostEnvKey = "DOCKER_HOST"
-)
-
 // DockerCommand is our main docker interface
 type DockerCommand struct {
 	Log                         *logrus.Entry


### PR DESCRIPTION
Let client automatically resolve compatible version with server. No breaking changes between 1.25 and latest for our uses.